### PR TITLE
Adding the plain error in the response

### DIFF
--- a/lib/Service.js
+++ b/lib/Service.js
@@ -131,8 +131,10 @@ class Service extends Component {
         delete this._pendingRequests[id];
 
         // ** Check for errors
-        if (res.error)
-            return req.fail(res.error);
+        if (res.error){
+            var err = errors.isError(res.error) ? res.error.toObject() : res.error;
+            return req.fail(err);
+        }
 
         // ** Request completed successfully
         req.complete(res.result);

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -13,6 +13,7 @@ const Component = require('./Component');
 const logger = require('nodus-framework').logging.createLogger();
 const errors = require('nodus-framework').errors;
 const functions = require('nodus-framework').functions;
+const util = require('util');
 
 /**
  * Constainer class for a request
@@ -132,7 +133,7 @@ class Service extends Component {
 
         // ** Check for errors
         if (res.error){
-            var err = errors.isError(res.error) ? res.error.toObject() : res.error;
+            var err = errors.isError(res.error) ? (util.isFunction(res.error.toObject) ? res.error.toObject() : res.error) : res.error;
             return req.fail(err);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodus-server",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Server Hosting Platform for nodus based applications.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
I've simply added a condition to check if the error in the response is a nodus error, if that's the case I'm converting it to object and using that object in the response.
Before my change:

```
{
  message: "[401] {"code":401,"data":"The provided credentials don't match with an existing user."}"
}
```

After my change:

```
{
  code: 401,
  data: {
    code: 401,
    data: "The provided credentials don't match with an existing user."
  },
  message: "[401] {"code":401,"data":"The provided credentials don't match with an existing user."}"
}
```

@bradserbu do you think this could bring any kind of error? for what I see the original contract is still fulfilled and now we have the raw message to use it in the client. I didn't want to mess with the actual structure of the error and that's why we see the code twice, and the message under data.data.
